### PR TITLE
refactor: FE/AI 백업 방식 개선

### DIFF
--- a/v1/ai/semi-automated/backup.sh
+++ b/v1/ai/semi-automated/backup.sh
@@ -13,9 +13,9 @@ fi
 mkdir -p "$BACKUP_DIR"
 
 # FastAPI 소스 백업 (필요 시 모델 파일 등도 포함 가능)
-if [ -d "$ROOT_DIR/ai-service" ]; then
-  echo "📦 AI 서비스 소스 백업 중..."
-  tar -czf "$BACKUP_DIR/$TIMESTAMP.tar.gz" -C "$ROOT_DIR" ai-service
+if [ -d "$SOURCE_DIR" ]; then
+  echo "📦 AI 백업 중..."
+  tar -czf "$BACKUP_DIR/$TIMESTAMP.tar.gz" -C "$SOURCE_DIR" .
 
   # 최대 7개만 유지
   ls -1t "$BACKUP_DIR" | tail -n +8 | xargs -I {} rm -f "$BACKUP_DIR/{}"

--- a/v1/frontend/semi-automated/backup.sh
+++ b/v1/frontend/semi-automated/backup.sh
@@ -12,9 +12,9 @@ fi
 
 mkdir -p "$BACKUP_DIR"
 
-# .next 빌드 산출물 백업
+# Frontend 소스 백업
 if [ -d "$SOURCE_DIR" ]; then
-  echo "📦 프론트엔드 빌드 산출물 백업 중..."
+  echo "📦 프론트엔드 백업 중..."
   tar -czf "$BACKUP_DIR/$TIMESTAMP.tar.gz" -C "$SOURCE_DIR" .
 
   # 최대 7개만 유지
@@ -22,5 +22,5 @@ if [ -d "$SOURCE_DIR" ]; then
 
   echo "✅ 백업 완료: $BACKUP_DIR/$TIMESTAMP.tar.gz"
 else
-  echo "❌ 백업할 빌드 산출물이 존재하지 않습니다: $SOURCE_DIR"
+  echo "❌ 백업할 소스 디렉토리가 존재하지 않습니다: $ROOT_DIR/ai-service"
 fi


### PR DESCRIPTION
## ✏️ 작업 개요
어떤 문서를 어떤 목적으로 작업하나요?

- 프론트엔드 백업 로직을 개선하여 `.next` 단독 백업이 아닌 전체 디렉토리 백업으로 전환
- 서버 내 `.env` 환경변수의 `SOURCE_DIR` 경로만 수정하면 반영 가능

## 🗂 작업 대상
- [x] `v1/frontend/semi-automated/backup.sh`
- [x] `v1/backend/semi-automated/backup.sh` (AI 서비스 경로 백업 포함)

## 📌 작업 상세 내용
- `.next` 단독 백업 → 프론트 전체 디렉토리 백업(`$SOURCE_DIR`)
- AI 서비스도 기존 경로 하드코딩 → `$SOURCE_DIR` 기반으로 유연하게 변경


## ⛓ 연관 이슈
- 연관 이슈: [[CL] FE 백업 방식 변경 #45](https://github.com/100-hours-a-week/6-nemo-cloud/issues/45)

---

## 💬 비고
- 서버 내 환경변수(`SOURCE_DIR`)만 경로에 맞춰 설정하면 바로 적용 가능  
- 백업 파일을 활용한 롤백 테스트는 추후 진행 예정