### PR TITLE
Infra: 도커 도입에 따른 배포 스크립트 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 envs
 .env
 .gitignore
+*.status

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   db:
+    container_name: db
     image: mysql:8.0
     ports:
       - "3306:3306"
@@ -11,6 +12,7 @@ services:
       - nemo-net
 
   backend:
+    container_name: backend
     build:
       context: ../../backend/backend-service
       dockerfile:  Dockerfile
@@ -19,22 +21,24 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - ../../cloud/v2/envs/be.env
+      - ../../cloud/v2/envs/backend.env
     networks:
       - nemo-net
 
   frontend:
+    container_name: frontend
     build:
       context: ../../frontend/frontend-service
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
     env_file:
-      - ../../cloud/v2/envs/fe.env
+      - ../../cloud/v2/envs/frontend.env
     networks:
       - nemo-net
 
   ai:
+    container_name: ai
     build:
       context: ../../ai/ai-service
       dockerfile: Dockerfile

--- a/v2/scripts/deploy.sh
+++ b/v2/scripts/deploy.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+SERVICE="$1"   # backend, frontend, ai
+ENV="$2"       # dev, prod
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📦 [1] 환경변수 및 공통 함수 로드"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+source "$HOME/nemo/cloud/v2/scripts/utils.sh"
+load_env "$SERVICE"
+
+cd "$ROOT_DIR"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📥 [2] 도커 이미지 Pull"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🔁 이미지: $IMAGE"
+docker pull "$IMAGE"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🐳 [3] 도커 컨테이너 실행"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [ "$ENV" == "dev" ]; then
+  docker compose up -d "$SERVICE_NAME"
+else
+  docker stop "$SERVICE_NAME" 2>/dev/null || true
+  docker rm "$SERVICE_NAME" 2>/dev/null || true
+  docker run -d --name "$SERVICE_NAME" \
+    --env-file "$ENV_FILE" \
+    -p "$PORT:$PORT" \
+    "$IMAGE"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🩺 [4] 헬스체크 수행"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if bash "$SCRIPT_DIR/healthcheck.sh" "$SERVICE"; then
+  notify_discord_all "✅ [배포 성공: $BRANCH] $SERVICE_NAME 배포 완료!"
+  echo ""
+  echo "🎉 [$SERVICE_NAME] 배포 완료"
+else
+  exit 1
+fi

--- a/v2/scripts/healthcheck.sh
+++ b/v2/scripts/healthcheck.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+SERVICE="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATUS_FILE="$SCRIPT_DIR/healthcheck_${SERVICE}.status"
+
+# 상태 파일 디렉토리 보장
+sudo mkdir -p "$(dirname "$STATUS_FILE")"
+
+source "$HOME/nemo/cloud/v2/scripts/utils.sh"
+load_env "$SERVICE"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🩺 [$SERVICE_NAME] 상태 확인 중..."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+MAX_RETRIES=10
+RETRY_INTERVAL=5
+STATUS=""
+
+for ((i=1; i<=MAX_RETRIES; i++)); do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTHCHECK_URL") || STATUS="000"
+
+  if [[ "$STATUS" =~ ^2|3 ]]; then
+    echo "✅ [$SERVICE_NAME] 정상 작동 (HTTP 200)"
+
+    # 복구 감지
+    if [ -f "$STATUS_FILE" ] && grep -q "unhealthy" "$STATUS_FILE"; then
+      notify_discord_cloud_only "✅ [헬스체크 복구: $BRANCH] $SERVICE_NAME 서비스 복구 완료! (응답: HTTP 200)"
+    fi
+
+    echo "healthy" | sudo tee "$STATUS_FILE" > /dev/null
+    exit 0
+  else
+    echo "⏳ [$SERVICE_NAME] 헬스체크 대기 중... ($i/$MAX_RETRIES) 응답: $STATUS"
+    sleep "$RETRY_INTERVAL"
+  fi
+done
+
+# 최종 실패 처리
+if [[ "$STATUS" == "000" ]]; then
+  STATUS_DESC="연결 실패 또는 타임아웃"
+else
+  STATUS_DESC="HTTP $STATUS"
+fi
+
+echo "❌ [$SERVICE_NAME] 서버 비정상 (응답: $STATUS_DESC)"
+
+if [ ! -f "$STATUS_FILE" ] || grep -q "healthy" "$STATUS_FILE"; then
+  notify_discord_cloud_only "❌ [헬스체크 실패: $BRANCH] $SERVICE_NAME 서비스 비정상 상태! (응답: $STATUS_DESC)"
+fi
+
+echo "unhealthy" | sudo tee "$STATUS_FILE" > /dev/null
+exit 1

--- a/v2/scripts/rollback.sh
+++ b/v2/scripts/rollback.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+SERVICE="$1"         # backend, frontend, ai
+ENV="$2"             # dev, prod
+ROLLBACK_TAG="$3"    # 롤백할 이미지 태그 (예: 20240604-1802)
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📦 [1] 환경변수 및 공통 함수 로드"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+source "$HOME/nemo/cloud/v2/scripts/utils.sh"
+load_env "$SERVICE"
+
+cd "$ROOT_DIR"
+
+if [ -z "$ROLLBACK_TAG" ]; then
+  echo "❌ 롤백할 태그가 없습니다. 인자로 태그명을 지정하세요."
+  exit 1
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📥 [2] 롤백 대상 이미지 Pull"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+ROLLBACK_IMAGE="$REGISTRY_URL/$SERVICE:$ROLLBACK_TAG"
+echo "🔁 롤백 이미지: $ROLLBACK_IMAGE"
+docker pull "$ROLLBACK_IMAGE"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🐳 [3] 컨테이너 재실행"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [ "$ENV" == "dev" ]; then
+  ROLLBACK_IMAGE="$ROLLBACK_IMAGE" docker compose up -d "$SERVICE_NAME"
+else
+  docker stop "$SERVICE_NAME" 2>/dev/null || true
+  docker rm "$SERVICE_NAME" 2>/dev/null || true
+  docker run -d --name "$SERVICE_NAME" \
+    --env-file "$ENV_FILE" \
+    -p "$PORT:$PORT" \
+    "$ROLLBACK_IMAGE"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🩺 [4] 롤백 후 헬스체크"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if bash "$SCRIPT_DIR/healthcheck.sh" "$SERVICE"; then
+  notify_discord_all "✅ [롤백 성공: $BRANCH] $SERVICE_NAME 롤백 완료! (Rollback Tag: $ROLLBACK_TAG)"
+  echo ""
+  echo "🎉 [$SERVICE_NAME] 롤백 완료"
+else
+  notify_discord_all "❌ [롤백 실패: $BRANCH] $SERVICE_NAME 롤백 실패! (Rollback Tag: $ROLLBACK_TAG)"
+  exit 1
+fi

--- a/v2/scripts/utils.sh
+++ b/v2/scripts/utils.sh
@@ -1,0 +1,52 @@
+# 환경변수 로드 함수 / $1: 서비스 이름
+load_env() {
+  local SERVICE="$1"
+
+  ENV_FILE="$HOME/nemo/cloud/v2/envs/${SERVICE}.env"
+
+  if [ -f "$ENV_FILE" ]; then
+    set -a
+    source "$ENV_FILE"
+    set +a
+  else
+    echo "❌ 환경변수 파일을 찾을 수 없습니다: $ENV_FILE"
+    exit 1
+  fi
+}
+
+# 클라우드 전용 알림 (헬스체크 실패)
+notify_discord_cloud_only() {
+  local message="$1"
+  curl -s -H "Content-Type: application/json" \
+       -X POST \
+       -d "{\"content\": \"$message\"}" \
+       "$WEBHOOK_CLOUD_URL" > /dev/null
+}
+
+# 클라우드 + 서비스 알림 (배포/롤백 결과)
+notify_discord_all() {
+  local message="$1"
+  local webhook_urls=()
+
+  # 클라우드 웹훅 항상 포함
+  if [ -n "${WEBHOOK_CLOUD_URL:-}" ]; then
+    webhook_urls+=("$WEBHOOK_CLOUD_URL")
+  fi
+
+  # 서비스 웹훅 동적 추출 (WEBHOOK_BACKEND_URL 등)
+  local upper_service
+  upper_service=$(echo "$SERVICE" | tr '[:lower:]' '[:upper:]')
+  local service_webhook_var="WEBHOOK_${upper_service}_URL"
+  local service_webhook="${!service_webhook_var:-}"
+
+  if [ -n "$service_webhook" ]; then
+    webhook_urls+=("$service_webhook")
+  fi
+
+  for webhook_url in "${webhook_urls[@]}"; do
+    curl -s -H "Content-Type: application/json" \
+         -X POST \
+         -d "{\"content\": \"$message\"}" \
+         "$webhook_url" > /dev/null
+  done
+}


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- 도커 도입에 따른 v2 배포 스크립트 작성

## Why
> 왜 이 작업을 했는지 설명합니다.

기존 배포 스크립트(deploy.sh, backup.sh, healthcheck.sh, rollback.sh, run.sh)는 수동 배포 기반으로 작성되어 있어, 도커 환경과 호환되지 않았습니다.
이에 따라, 도커 기반 배포에 맞는 새로운 스크립트를 구성하게 되었습니다.

## Changes
> 주요 변경사항을 적습니다.

- 서비스별 스크립트(v1)를 제거하고, 공통화된 스크립트(v2) 구조로 재설계하여 유지보수성과 재사용성 개선
- 환경변수만 다르게 설정하면 동일한 스크립트로 모든 서비스(AI, FE, BE) 배포 가능
- 가독성을 위해 이모지 및 구분선 적극 활용 (디버깅 가독성 향상)
- 기존에는 서버 내 백업이 필요했으나, Artifact Registry 도입으로 CI 레벨에서 이미지 백업 수행
- 헬스체크 실패 후 복구 시 알림 기능 추가 → 이전에는 실패 알림만 존재
- 환경(dev/prod)에 따라 실행 방식 분기
  - dev: docker compose
  - prod: docker run
  - 동일한 스크립트를 두 환경 모두에서 사용할 수 있게 개선
- 공통 함수(utils.sh) 분리
- 환경변수 로드, Discord 알림 등 중복 코드 제거 및 함수 호출 방식으로 간소화
- 헬스체크 고도화
   - 기존: 단순 sleep 후 확인
   - 개선: 최대 10회/50초 간격 재시도 → 응답 즉시 판단


- 스크립트 실행 가이드
  ```
  # 배포
  bash deploy.sh <서비스명: frontend | backend | ai> <환경: dev | prod>
  
  # 롤백
  bash rollback.sh <서비스명> <환경> <롤백 태그: e.g. 20240604-1802>
  
  # 헬스체크 단독 실행
  bash healthcheck.sh <서비스명>
  
  ```

- 예시
  ```
  bash deploy.sh backend prod
  bash rollback.sh ai dev dev-latest
  bash healthcheck.sh frontend
  ```

## Related Issue
> 관련 이슈 번호를 연결합니다.

- https://github.com/orgs/100-hours-a-week/projects/146/views/1?sliceBy%5Bvalue%5D=%F0%9F%95%8B+CL&pane=issue&itemId=3120234174&issue=100-hours-a-week%7C6-nemo-cloud%7C64
