### PR TITLE
Feat: AI 프로젝트 분리에 따른 docker-compose 설정 추가

### DIFF
--- a/v2/docker-compose.dev.yaml
+++ b/v2/docker-compose.dev.yaml
@@ -51,6 +51,16 @@ services:
       - nemo-net
     restart: unless-stopped
 
+  ai:
+    container_name: ai-dev
+    image: asia-northeast3-docker.pkg.dev/nemo-v2-ai-461016/registry/ai:dev-latest
+    ports:
+      - "8100:8000"
+    env_file:
+      - ../../cloud/v2/envs/ai.dev.env
+    networks:
+      - nemo-net
+
 networks:
   nemo-net:
 

--- a/v2/docker-compose.prod.yaml
+++ b/v2/docker-compose.prod.yaml
@@ -19,6 +19,17 @@ services:
       - ../../cloud/v2/envs/frontend.prod.env
     networks:
       - nemo-net
+  
+  ai:
+    container_name: ai-prod
+    image: asia-northeast3-docker.pkg.dev/nemo-v2-ai-461016/registry/ai:prod-latest
+    ports:
+      - "8000:8000"
+    env_file:
+      - ../../cloud/v2/envs/ai.prod.env
+    networks:
+      - nemo-net
+    restart: unless-stopped
 
 networks:
   nemo-net:


### PR DESCRIPTION
## What  
> 무엇을 작업했는지 간결하게 적습니다.

- AI 서비스의 dev/prod 환경을 병렬로 운영할 수 있도록 `docker-compose` 설정을 분리 및 추가했습니다.

## Why  
> 왜 이 작업을 했는지 설명합니다.

- 단일 GPU 서버 환경에서 dev와 prod 컨테이너를 동시에 실행할 수 없기 때문에,
  포트 분리를 통해 병렬 테스트가 가능하도록 하기 위함입니다.
- 운영 환경(prod)은 자동 복구가 필요하지만, dev는 수동 테스트용으로 제한적으로 사용할 계획입니다.


## Changes  
> 주요 변경사항을 적습니다.

- `ai-prod` 서비스 추가: `8000:8000`, `.env` 분리, `restart: unless-stopped` 적용
- `ai-dev` 서비스 추가: `8100:8000`, `.env` 분리, `restart` 옵션 미적용 (수동 운영)
- `container_name`, `env_file`, `ports` 등 명시적으로 dev/prod 분리
- 공통 네트워크 `nemo-net` 사용


## Related Issue  
- https://github.com/orgs/100-hours-a-week/projects/146/views/1?sliceBy%5Bvalue%5D=%F0%9F%95%8B+CL&pane=issue&itemId=3157514669&issue=100-hours-a-week%7C6-nemo-cloud%7C67