### PR TITLE
[Infra] 서버 스케줄링 작업 및 서버 시작 & 종료 알림 스크립트 추가

### DIFF
--- a/v2/docker-compose.dev.yaml
+++ b/v2/docker-compose.dev.yaml
@@ -56,7 +56,7 @@ services:
     container_name: ai-dev
     image: asia-northeast3-docker.pkg.dev/nemo-v2-ai-461016/registry/ai:dev-latest
     ports:
-      - "8100:8000"
+      - "8001:8000"
     env_file:
       - ../../cloud/v2/envs/ai.dev.env
     volumes:

--- a/v2/scripts/deploy.sh
+++ b/v2/scripts/deploy.sh
@@ -8,7 +8,6 @@ ENV="$2"     # dev or prod
 # 경로 설정
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-ENV_FILE="$ROOT_DIR/envs/${SERVICE}.${ENV}.env"
 COMPOSE_FILE="docker-compose.${ENV}.yaml"
 
 # 이미지 경로 분기 처리

--- a/v2/scripts/shutdown.sh
+++ b/v2/scripts/shutdown.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# 인자 설정
+SERVICE="$1" # backend, frontend, ai
+ENV="$2"     # dev or prod
+
+# 경로 설정
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# 유틸 불러오기
+source "$SCRIPT_DIR/utils.sh"
+
+# 루트로 이동
+cd "$ROOT_DIR"
+
+# 환경변수 로드
+echo "🔧 [$ENV] 환경변수 로드 중..."
+load_env "$SERVICE" "$ENV"
+
+# 종료 알림
+notify_discord_cloud_only "🌙 [서버 종료: $ENV] $SERVICE 서버 종료!"

--- a/v2/scripts/startup.sh
+++ b/v2/scripts/startup.sh
@@ -1,48 +1,33 @@
 #!/bin/bash
+set -euo pipefail
 
-echo "[INFO] Running startup script..."
+# 인자 설정
+SERVICE="$1" # backend, frontend, ai
+ENV="$2"     # dev or prod
 
-SERVICE="$1"   # backend, frontend, ai
-ENV=prod       # dev or prod
-
+# 경로 설정
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd /home/ubuntu/nemo/cloud/v2 || exit 1
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="docker-compose.${ENV}.yaml"
 
-echo "[INFO] Pulling latest cloud repo..."
-git pull origin develop || echo "[WARN] git pull 실패"
+# 유틸 불러오기
 source "$SCRIPT_DIR/utils.sh"
 
-PROJECT_ID="nemo-v2-prod"
-SECRET_NAME="${SERVICE}-${ENV}-env"
-ENV_FILE="./envs/${SERVICE}.${ENV}.env"
+# 루트로 이동
+cd "$ROOT_DIR"
 
-echo "[INFO] Fetching env from Secret Manager for $SERVICE ($ENV)..."
-if SECRET_CONTENT=$(gcloud secrets versions access latest \
-    --secret="$SECRET_NAME" \
-    --project="$PROJECT_ID"); then
-    echo "$SECRET_CONTENT" > "$ENV_FILE"
-    echo "[INFO] Saved to $ENV_FILE"
-else
-    echo "❌ Failed to fetch secret: $SECRET_NAME"
-    exit 1
-fi
+# 환경변수 로드
+echo "🔧 [$ENV] 환경변수 로드 중..."
+load_env "$SERVICE" "$ENV"
 
-echo "[INFO] Pulling latest docker image for $SERVICE..."
-docker compose -f docker-compose.prod.yaml pull "$SERVICE"
+# 도커 컴포즈 실행
+echo "🐳 도커 컴포즈로 실행 중..."
+docker compose -f "$COMPOSE_FILE" up -d "$SERVICE" || true
 
-echo "[INFO] Starting docker container for $SERVICE..."
-docker compose -f docker-compose.prod.yaml up -d --force-recreate "$SERVICE"
-
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "🩺 [$SERVICE] 헬스체크 수행"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+# 헬스체크 후 시작 알림
 if bash "$SCRIPT_DIR/healthcheck.sh" "$SERVICE" "$ENV"; then
-  notify_discord_all "✅ [배포 성공: $BRANCH] $SERVICE 배포 완료!"
-  echo "🎉 [$SERVICE] 배포 완료"
+  notify_discord_cloud_only "☀️ [서버 시작: $ENV] $SERVICE 서버 시작!"
 else
-  notify_discord_all "❌ [배포 실패: $BRANCH] $SERVICE 배포 실패!"
+  notify_discord_cloud_only "❌ [헬스체크 실패: $ENV] $SERVICE 서비스 비정상 상태! (응답: $STATUS_DESC)"
   exit 1
 fi
-
-echo "[INFO] Startup script completed."


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- GCP VM 인스턴스 자동 시작/종료를 위한 스케줄링 자동화 구성
- 서비스별 `startup-script`, `shutdown-script` 작성 및 VM 메타데이터에 적용
- Discord 알림 연동 포함 (서버 시작/종료/헬스체크 실패 시)

## Why
> 왜 이 작업을 했는지 설명합니다.

- AI 서버 및 기타 리소스를 필요한 시간에만 자동 운영하여 비용 최적화
- 수동 관리 없이 인프라가 자동으로 켜지고 꺼지도록 하기 위함
- 서버 시작 상태 확인 및 운영 편의성을 위해 헬스체크 + 알림 기능 추가

## Changes
> 주요 변경사항을 적습니다.

- `startup.sh`: 
  - 환경변수 로드 → `docker compose` 실행 → 헬스체크 → Discord 알림 전송
- `shutdown.sh`: 
  - 종료 알림 Discord 전송
- `utils.sh`: 
  - Secret Manager 연동, Webhook 함수 통합
- VM 메타데이터 설정:
  - `startup-script`: `git pull` + `startup.sh ai prod`
  - `shutdown-script`: `shutdown.sh ai prod`
- GCP 서비스 계정 권한:
  - `service-<PROJECT_NUM>@compute-system.iam.gserviceaccount.com`에 `Compute 인스턴스 관리자(v1)` 역할 부여

## Related Issue
- https://github.com/orgs/100-hours-a-week/projects/146/views/1?sliceBy%5Bvalue%5D=%F0%9F%95%8B+CL&pane=issue&itemId=116115342&issue=100-hours-a-week%7C6-nemo-wiki%7C229
