### PR TITLE
Feat: add redis-exporter container for Signoz

### DIFF
--- a/v2/docker-compose.dev.yaml
+++ b/v2/docker-compose.dev.yaml
@@ -27,6 +27,18 @@ services:
       - nemo-net
     restart: unless-stopped
 
+  redis-exporter:
+    image: bitnami/redis-exporter:latest
+    container_name: redis-exporter
+    restart: unless-stopped
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+    ports:
+      - "9121:9121"
+    networks:
+      - nemo-net
+    depends_on:
+      - redis
 
   backend:
     container_name: backend


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- docker-compose.dev.yaml 에 redis-exporter 컨테이너 정의를 추가했습니다. 

## Why
> 왜 이 작업을 했는지 설명합니다.

- Redis 성능 및 상태를 SigNoz를 통해 모니터링하기 위해 redis-exporter를 추가했습니다.

## Changes
> 주요 변경사항을 적습니다.

- v2/docker-compose.dev.yaml 파일 수정
- redis-exporter 서비스 정의 추가
- SigNoz에서 Redis 메트릭 수집 가능하도록 준비

## Related Issue
> 관련 이슈 번호를 연결합니다.

- #73 
