### PR TITLE
Infra/v2 ai docker compose lillian

### DIFF
--- a/v2/docker-compose.ai.yaml
+++ b/v2/docker-compose.ai.yaml
@@ -29,13 +29,21 @@ services:
   vllm:
     container_name: vllm
     image: vllm/vllm-openai:latest
+    entrypoint: "" 
     ports:
       - "8002:8000"
     command: >
-      --model chaerheeon/nemo-chatbot-v3
-      --host 0.0.0.0
-      --dtype float16
-      --gpu-memory-utilization 0.7
+      bash -c "
+      pip install huggingface_hub &&
+      python3 -c 'from huggingface_hub import snapshot_download; snapshot_download(repo_id=\"chaerheeon/nemo-chatbot-v3\", local_dir=\"/model\", local_dir_use_symlinks=False)' &&
+      python3 -m vllm.entrypoints.openai.api_server
+        --model /model
+        --tokenizer /model
+        --chat-template /model/chat_template.jinja
+        --host 0.0.0.0
+        --port 8000
+        --dtype float16
+        --gpu-memory-utilization 0.7"
     runtime: nvidia
     networks:
       - nemo-net
@@ -45,7 +53,4 @@ services:
           devices:
             - capabilities: [gpu]
     restart: unless-stopped
-
-networks:
-  nemo-net:
 

--- a/v2/docker-compose.ai.yaml
+++ b/v2/docker-compose.ai.yaml
@@ -53,4 +53,5 @@ services:
           devices:
             - capabilities: [gpu]
     restart: unless-stopped
-
+networks:
+      - nemo-net


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- vLLM 컨테이너에서 Hugging Face 모델 저장소로부터 `chat_template.jinja`를 자동 다운로드하여 사용하는 기능을 추가했습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

- OpenAI API 호환을 위해 vLLM의 `chat/completions` 엔드포인트에서 사용자 정의 채팅 템플릿을 적용하려면 `chat_template.jinja`가 필요합니다.
- tokenizer_config.json에 정의된 chat_template는 vLLM에서 인식되지 않기 때문에, 별도로 `.jinja` 파일을 다운로드 후 명시적으로 지정해줘야 합니다.

## Changes
> 주요 변경사항을 적습니다.

- vLLM 컨테이너 내 `command`에 `huggingface_hub` 설치 및 `snapshot_download()` 실행 로직 추가
- 모델과 템플릿 파일을 `/model` 경로에 다운로드
- `--chat-template /model/chat_template.jinja` 플래그로 Jinja 템플릿 명시