### PR TITLE
Feat: 테라폼으로 3-tier 아키텍쳐 구축 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ envs
 .env
 .gitignore
 *.status
+**/.terraform/

--- a/v3/env/prod/.terraform.lock.hcl
+++ b/v3/env/prod/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.0.0"
+  hashes = [
+    "h1:dbRRZ1NzH1QV/+83xT/X3MLYaZobMXt8DNwbqnJojpo=",
+    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
+    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
+    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
+    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
+    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
+    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
+    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
+    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
+    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
+    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
+    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
+    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
+    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
+  ]
+}

--- a/v3/env/prod/main.tf
+++ b/v3/env/prod/main.tf
@@ -2,4 +2,7 @@ module "vpc" {
   source   = "../../modules/vpc"
   name     = "prod"
   vpc_cidr = "10.0.0.0/16"
+  public_subnet_cidr = "10.0.1.0/24"
+  private_subnet_cidr = "10.0.2.0/24"
+  subnet_az = ["ap-northeast-2a", "ap-northeast-2c"]
 }

--- a/v3/env/prod/main.tf
+++ b/v3/env/prod/main.tf
@@ -1,0 +1,5 @@
+module "vpc" {
+  source   = "../../modules/vpc"
+  name     = "prod"
+  vpc_cidr = "10.0.0.0/16"
+}

--- a/v3/env/prod/provider.tf
+++ b/v3/env/prod/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/v3/env/prod/terraform.tfstate
+++ b/v3/env/prod/terraform.tfstate
@@ -1,10 +1,51 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 10,
+  "serial": 23,
   "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
   "outputs": {},
   "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "nat",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "address": null,
+            "allocation_id": "eipalloc-02e579a6cf4d904af",
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:elastic-ip/eipalloc-02e579a6cf4d904af",
+            "associate_with_private_ip": null,
+            "association_id": "eipassoc-0692f7871f04c8799",
+            "carrier_ip": "",
+            "customer_owned_ip": "",
+            "customer_owned_ipv4_pool": "",
+            "domain": "vpc",
+            "id": "eipalloc-02e579a6cf4d904af",
+            "instance": "",
+            "ipam_pool_id": null,
+            "network_border_group": "ap-northeast-2",
+            "network_interface": "eni-0a24900292e110f6a",
+            "private_dns": "ip-10-0-1-182.ap-northeast-2.compute.internal",
+            "private_ip": "10.0.1.182",
+            "ptr_record": "",
+            "public_dns": "ec2-3-37-178-232.ap-northeast-2.compute.amazonaws.com",
+            "public_ip": "3.37.178.232",
+            "public_ipv4_pool": "amazon",
+            "region": "ap-northeast-2",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxODAwMDAwMDAwMDAsInJlYWQiOjkwMDAwMDAwMDAwMCwidXBkYXRlIjozMDAwMDAwMDAwMDB9fQ=="
+        }
+      ]
+    },
     {
       "module": "module.vpc",
       "mode": "managed",
@@ -32,6 +73,100 @@
           "identity_schema_version": 0,
           "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
           "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_nat_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "allocation_id": "eipalloc-02e579a6cf4d904af",
+            "association_id": "eipassoc-0692f7871f04c8799",
+            "connectivity_type": "public",
+            "id": "nat-0874c66266d0c9652",
+            "network_interface_id": "eni-0a24900292e110f6a",
+            "private_ip": "10.0.1.182",
+            "public_ip": "3.37.178.232",
+            "region": "ap-northeast-2",
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_address_count": 0,
+            "secondary_private_ip_addresses": [],
+            "subnet_id": "subnet-01330e7a44f49d6b2",
+            "tags": {
+              "Name": "prod-NGW"
+            },
+            "tags_all": {
+              "Name": "prod-NGW"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTgwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9fQ==",
+          "dependencies": [
+            "module.vpc.aws_eip.nat",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:route-table/rtb-09830fe55b3afff7a",
+            "id": "rtb-09830fe55b3afff7a",
+            "owner_id": "084375578827",
+            "propagating_vgws": [],
+            "region": "ap-northeast-2",
+            "route": [
+              {
+                "carrier_gateway_id": "",
+                "cidr_block": "0.0.0.0/0",
+                "core_network_arn": "",
+                "destination_prefix_list_id": "",
+                "egress_only_gateway_id": "",
+                "gateway_id": "",
+                "ipv6_cidr_block": "",
+                "local_gateway_id": "",
+                "nat_gateway_id": "nat-0874c66266d0c9652",
+                "network_interface_id": "",
+                "transit_gateway_id": "",
+                "vpc_endpoint_id": "",
+                "vpc_peering_connection_id": ""
+              }
+            ],
+            "tags": {
+              "Name": "prod-private-RT"
+            },
+            "tags_all": {
+              "Name": "prod-private-RT"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_eip.nat",
+            "module.vpc.aws_nat_gateway.this",
+            "module.vpc.aws_subnet.public",
             "module.vpc.aws_vpc.this"
           ]
         }
@@ -92,14 +227,45 @@
       "module": "module.vpc",
       "mode": "managed",
       "type": "aws_route_table_association",
-      "name": "RT1",
+      "name": "private",
       "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
       "instances": [
         {
           "schema_version": 0,
           "attributes": {
             "gateway_id": "",
-            "id": "rtbassoc-067fb89aa75de12bb",
+            "id": "rtbassoc-009dd49daaaafc050",
+            "region": "ap-northeast-2",
+            "route_table_id": "rtb-09830fe55b3afff7a",
+            "subnet_id": "subnet-0462f75e40a662517",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_eip.nat",
+            "module.vpc.aws_nat_gateway.this",
+            "module.vpc.aws_route_table.private",
+            "module.vpc.aws_subnet.private",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-04c4f50ac2938745c",
             "region": "ap-northeast-2",
             "route_table_id": "rtb-08ea2f67817420cf6",
             "subnet_id": "subnet-01330e7a44f49d6b2",

--- a/v3/env/prod/terraform.tfstate
+++ b/v3/env/prod/terraform.tfstate
@@ -1,0 +1,55 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.2",
+  "serial": 1,
+  "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
+  "outputs": {},
+  "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:vpc/vpc-04d062e8879f95adf",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-00ddeada7a1ee1b40",
+            "default_route_table_id": "rtb-027b06b29a37379be",
+            "default_security_group_id": "sg-0068a9079da04ac9a",
+            "dhcp_options_id": "dopt-0f5a6807b7f134617",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-04d062e8879f95adf",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-027b06b29a37379be",
+            "owner_id": "084375578827",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-vpc"
+            },
+            "tags_all": {
+              "Name": "prod-vpc"
+            }
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/v3/env/prod/terraform.tfstate
+++ b/v3/env/prod/terraform.tfstate
@@ -1,10 +1,106 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 1,
+  "serial": 5,
   "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
   "outputs": {},
   "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:subnet/subnet-0462f75e40a662517",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "ap-northeast-2a",
+            "availability_zone_id": "apne2-az1",
+            "cidr_block": "10.0.2.0/24",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-0462f75e40a662517",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "084375578827",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-private-subnet"
+            },
+            "tags_all": {
+              "Name": "prod-private-subnet"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:subnet/subnet-01330e7a44f49d6b2",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "ap-northeast-2a",
+            "availability_zone_id": "apne2-az1",
+            "cidr_block": "10.0.1.0/24",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-01330e7a44f49d6b2",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "084375578827",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-public-subnet"
+            },
+            "tags_all": {
+              "Name": "prod-public-subnet"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
     {
       "module": "module.vpc",
       "mode": "managed",
@@ -38,10 +134,10 @@
             "owner_id": "084375578827",
             "region": "ap-northeast-2",
             "tags": {
-              "Name": "prod-vpc"
+              "Name": "v3-nemo-prod-vpc"
             },
             "tags_all": {
-              "Name": "prod-vpc"
+              "Name": "v3-nemo-prod-vpc"
             }
           },
           "sensitive_attributes": [],

--- a/v3/env/prod/terraform.tfstate
+++ b/v3/env/prod/terraform.tfstate
@@ -1,10 +1,122 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 5,
+  "serial": 10,
   "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
   "outputs": {},
   "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:internet-gateway/igw-0ce7ee56216d54ff5",
+            "id": "igw-0ce7ee56216d54ff5",
+            "owner_id": "084375578827",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-IGW"
+            },
+            "tags_all": {
+              "Name": "prod-IGW"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:route-table/rtb-08ea2f67817420cf6",
+            "id": "rtb-08ea2f67817420cf6",
+            "owner_id": "084375578827",
+            "propagating_vgws": [],
+            "region": "ap-northeast-2",
+            "route": [
+              {
+                "carrier_gateway_id": "",
+                "cidr_block": "0.0.0.0/0",
+                "core_network_arn": "",
+                "destination_prefix_list_id": "",
+                "egress_only_gateway_id": "",
+                "gateway_id": "igw-0ce7ee56216d54ff5",
+                "ipv6_cidr_block": "",
+                "local_gateway_id": "",
+                "nat_gateway_id": "",
+                "network_interface_id": "",
+                "transit_gateway_id": "",
+                "vpc_endpoint_id": "",
+                "vpc_peering_connection_id": ""
+              }
+            ],
+            "tags": {
+              "Name": "prod-public-RT"
+            },
+            "tags_all": {
+              "Name": "prod-public-RT"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_internet_gateway.this",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "RT1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-067fb89aa75de12bb",
+            "region": "ap-northeast-2",
+            "route_table_id": "rtb-08ea2f67817420cf6",
+            "subnet_id": "subnet-01330e7a44f49d6b2",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_internet_gateway.this",
+            "module.vpc.aws_route_table.public",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
     {
       "module": "module.vpc",
       "mode": "managed",
@@ -134,10 +246,10 @@
             "owner_id": "084375578827",
             "region": "ap-northeast-2",
             "tags": {
-              "Name": "v3-nemo-prod-vpc"
+              "Name": "prod-VPC"
             },
             "tags_all": {
-              "Name": "v3-nemo-prod-vpc"
+              "Name": "prod-VPC"
             }
           },
           "sensitive_attributes": [],

--- a/v3/env/prod/terraform.tfstate.backup
+++ b/v3/env/prod/terraform.tfstate.backup
@@ -1,0 +1,55 @@
+{
+  "version": 4,
+  "terraform_version": "1.12.2",
+  "serial": 1,
+  "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
+  "outputs": {},
+  "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:vpc/vpc-04d062e8879f95adf",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.0.0.0/16",
+            "default_network_acl_id": "acl-00ddeada7a1ee1b40",
+            "default_route_table_id": "rtb-027b06b29a37379be",
+            "default_security_group_id": "sg-0068a9079da04ac9a",
+            "dhcp_options_id": "dopt-0f5a6807b7f134617",
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "enable_network_address_usage_metrics": false,
+            "id": "vpc-04d062e8879f95adf",
+            "instance_tenancy": "default",
+            "ipv4_ipam_pool_id": null,
+            "ipv4_netmask_length": null,
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_network_border_group": "",
+            "ipv6_ipam_pool_id": "",
+            "ipv6_netmask_length": 0,
+            "main_route_table_id": "rtb-027b06b29a37379be",
+            "owner_id": "084375578827",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-vpc"
+            },
+            "tags_all": {
+              "Name": "prod-vpc"
+            }
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/v3/env/prod/terraform.tfstate.backup
+++ b/v3/env/prod/terraform.tfstate.backup
@@ -1,10 +1,106 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 1,
+  "serial": 5,
   "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
   "outputs": {},
   "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:subnet/subnet-0462f75e40a662517",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "ap-northeast-2a",
+            "availability_zone_id": "apne2-az1",
+            "cidr_block": "10.0.2.0/24",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-0462f75e40a662517",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "084375578827",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-private-subnet"
+            },
+            "tags_all": {
+              "Name": "prod-private-subnet"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:subnet/subnet-01330e7a44f49d6b2",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "ap-northeast-2a",
+            "availability_zone_id": "apne2-az1",
+            "cidr_block": "10.0.1.0/24",
+            "customer_owned_ipv4_pool": "",
+            "enable_dns64": false,
+            "enable_lni_at_device_index": 0,
+            "enable_resource_name_dns_a_record_on_launch": false,
+            "enable_resource_name_dns_aaaa_record_on_launch": false,
+            "id": "subnet-01330e7a44f49d6b2",
+            "ipv6_cidr_block": "",
+            "ipv6_cidr_block_association_id": "",
+            "ipv6_native": false,
+            "map_customer_owned_ip_on_launch": false,
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "owner_id": "084375578827",
+            "private_dns_hostname_type_on_launch": "ip-name",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-public-subnet"
+            },
+            "tags_all": {
+              "Name": "prod-public-subnet"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTIwMDAwMDAwMDAwMH0sInNjaGVtYV92ZXJzaW9uIjoiMSJ9",
+          "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
     {
       "module": "module.vpc",
       "mode": "managed",
@@ -38,10 +134,10 @@
             "owner_id": "084375578827",
             "region": "ap-northeast-2",
             "tags": {
-              "Name": "prod-vpc"
+              "Name": "v3-nemo-prod-vpc"
             },
             "tags_all": {
-              "Name": "prod-vpc"
+              "Name": "v3-nemo-prod-vpc"
             }
           },
           "sensitive_attributes": [],

--- a/v3/env/prod/terraform.tfstate.backup
+++ b/v3/env/prod/terraform.tfstate.backup
@@ -1,10 +1,288 @@
 {
   "version": 4,
   "terraform_version": "1.12.2",
-  "serial": 5,
+  "serial": 21,
   "lineage": "e7eeef84-680d-ac7f-969d-c92989ed13b2",
   "outputs": {},
   "resources": [
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "nat",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "address": null,
+            "allocation_id": "eipalloc-02e579a6cf4d904af",
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:elastic-ip/eipalloc-02e579a6cf4d904af",
+            "associate_with_private_ip": null,
+            "association_id": "eipassoc-0692f7871f04c8799",
+            "carrier_ip": "",
+            "customer_owned_ip": "",
+            "customer_owned_ipv4_pool": "",
+            "domain": "vpc",
+            "id": "eipalloc-02e579a6cf4d904af",
+            "instance": "",
+            "ipam_pool_id": null,
+            "network_border_group": "ap-northeast-2",
+            "network_interface": "eni-0a24900292e110f6a",
+            "private_dns": "ip-10-0-1-182.ap-northeast-2.compute.internal",
+            "private_ip": "10.0.1.182",
+            "ptr_record": "",
+            "public_dns": "ec2-3-37-178-232.ap-northeast-2.compute.amazonaws.com",
+            "public_ip": "3.37.178.232",
+            "public_ipv4_pool": "amazon",
+            "region": "ap-northeast-2",
+            "tags": {},
+            "tags_all": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiZGVsZXRlIjoxODAwMDAwMDAwMDAsInJlYWQiOjkwMDAwMDAwMDAwMCwidXBkYXRlIjozMDAwMDAwMDAwMDB9fQ=="
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:internet-gateway/igw-0ce7ee56216d54ff5",
+            "id": "igw-0ce7ee56216d54ff5",
+            "owner_id": "084375578827",
+            "region": "ap-northeast-2",
+            "tags": {
+              "Name": "prod-IGW"
+            },
+            "tags_all": {
+              "Name": "prod-IGW"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoxMjAwMDAwMDAwMDAwLCJkZWxldGUiOjEyMDAwMDAwMDAwMDAsInVwZGF0ZSI6MTIwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_nat_gateway",
+      "name": "this",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "allocation_id": "eipalloc-02e579a6cf4d904af",
+            "association_id": "eipassoc-0692f7871f04c8799",
+            "connectivity_type": "public",
+            "id": "nat-0874c66266d0c9652",
+            "network_interface_id": "eni-0a24900292e110f6a",
+            "private_ip": "10.0.1.182",
+            "public_ip": "3.37.178.232",
+            "region": "ap-northeast-2",
+            "secondary_allocation_ids": [],
+            "secondary_private_ip_address_count": 0,
+            "secondary_private_ip_addresses": [],
+            "subnet_id": "subnet-01330e7a44f49d6b2",
+            "tags": {
+              "Name": "prod-NGW"
+            },
+            "tags_all": {
+              "Name": "prod-NGW"
+            },
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6MTgwMDAwMDAwMDAwMCwidXBkYXRlIjo2MDAwMDAwMDAwMDB9fQ==",
+          "dependencies": [
+            "module.vpc.aws_eip.nat",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:route-table/rtb-09830fe55b3afff7a",
+            "id": "rtb-09830fe55b3afff7a",
+            "owner_id": "084375578827",
+            "propagating_vgws": [],
+            "region": "ap-northeast-2",
+            "route": [
+              {
+                "carrier_gateway_id": "",
+                "cidr_block": "0.0.0.0/0",
+                "core_network_arn": "",
+                "destination_prefix_list_id": "",
+                "egress_only_gateway_id": "",
+                "gateway_id": "",
+                "ipv6_cidr_block": "",
+                "local_gateway_id": "",
+                "nat_gateway_id": "nat-0874c66266d0c9652",
+                "network_interface_id": "",
+                "transit_gateway_id": "",
+                "vpc_endpoint_id": "",
+                "vpc_peering_connection_id": ""
+              }
+            ],
+            "tags": {
+              "Name": "prod-private-RT"
+            },
+            "tags_all": {
+              "Name": "prod-private-RT"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_eip.nat",
+            "module.vpc.aws_nat_gateway.this",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "arn": "arn:aws:ec2:ap-northeast-2:084375578827:route-table/rtb-08ea2f67817420cf6",
+            "id": "rtb-08ea2f67817420cf6",
+            "owner_id": "084375578827",
+            "propagating_vgws": [],
+            "region": "ap-northeast-2",
+            "route": [
+              {
+                "carrier_gateway_id": "",
+                "cidr_block": "0.0.0.0/0",
+                "core_network_arn": "",
+                "destination_prefix_list_id": "",
+                "egress_only_gateway_id": "",
+                "gateway_id": "igw-0ce7ee56216d54ff5",
+                "ipv6_cidr_block": "",
+                "local_gateway_id": "",
+                "nat_gateway_id": "",
+                "network_interface_id": "",
+                "transit_gateway_id": "",
+                "vpc_endpoint_id": "",
+                "vpc_peering_connection_id": ""
+              }
+            ],
+            "tags": {
+              "Name": "prod-RT"
+            },
+            "tags_all": {
+              "Name": "prod-RT"
+            },
+            "timeouts": null,
+            "vpc_id": "vpc-04d062e8879f95adf"
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_internet_gateway.this",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "private",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-009dd49daaaafc050",
+            "region": "ap-northeast-2",
+            "route_table_id": "rtb-09830fe55b3afff7a",
+            "subnet_id": "subnet-0462f75e40a662517",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_eip.nat",
+            "module.vpc.aws_nat_gateway.this",
+            "module.vpc.aws_route_table.private",
+            "module.vpc.aws_subnet.private",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.vpc",
+      "mode": "managed",
+      "type": "aws_route_table_association",
+      "name": "public",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "gateway_id": "",
+            "id": "rtbassoc-04c4f50ac2938745c",
+            "region": "ap-northeast-2",
+            "route_table_id": "rtb-08ea2f67817420cf6",
+            "subnet_id": "subnet-01330e7a44f49d6b2",
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "identity_schema_version": 0,
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozMDAwMDAwMDAwMDAsImRlbGV0ZSI6MzAwMDAwMDAwMDAwLCJ1cGRhdGUiOjEyMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "module.vpc.aws_internet_gateway.this",
+            "module.vpc.aws_route_table.public",
+            "module.vpc.aws_subnet.public",
+            "module.vpc.aws_vpc.this"
+          ]
+        }
+      ]
+    },
     {
       "module": "module.vpc",
       "mode": "managed",
@@ -134,10 +412,10 @@
             "owner_id": "084375578827",
             "region": "ap-northeast-2",
             "tags": {
-              "Name": "v3-nemo-prod-vpc"
+              "Name": "prod-VPC"
             },
             "tags_all": {
-              "Name": "v3-nemo-prod-vpc"
+              "Name": "prod-VPC"
             }
           },
           "sensitive_attributes": [],

--- a/v3/modules/vpc/main.tf
+++ b/v3/modules/vpc/main.tf
@@ -3,7 +3,25 @@ resource "aws_vpc" "this" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = {
-    Name = "${var.name}-vpc"
+  tags = { 
+    Name = "v3-nemo-${var.name}-vpc"
+  }
+}
+
+resource "aws_subnet" "public" {
+  cidr_block            = var.public_subnet_cidr
+  availability_zone     = var.subnet_az[0]
+  vpc_id                = aws_vpc.this.id
+  tags = { 
+    Name = "${var.name}-public-subnet"
+  }
+}
+
+resource "aws_subnet" "private" {
+  cidr_block            = var.private_subnet_cidr
+  availability_zone     = var.subnet_az[0]
+  vpc_id                = aws_vpc.this.id
+  tags = { 
+    Name = "${var.name}-private-subnet"
   }
 }

--- a/v3/modules/vpc/main.tf
+++ b/v3/modules/vpc/main.tf
@@ -1,0 +1,9 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.name}-vpc"
+  }
+}

--- a/v3/modules/vpc/main.tf
+++ b/v3/modules/vpc/main.tf
@@ -4,7 +4,7 @@ resource "aws_vpc" "this" {
   enable_dns_hostnames = true
 
   tags = { 
-    Name = "v3-nemo-${var.name}-vpc"
+    Name = "${var.name}-VPC"
   }
 }
 
@@ -24,4 +24,62 @@ resource "aws_subnet" "private" {
   tags = { 
     Name = "${var.name}-private-subnet"
   }
+}
+
+resource "aws_internet_gateway" "this"{
+  vpc_id                = aws_vpc.this.id
+  tags = { 
+    Name = "${var.name}-IGW"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id                = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+  tags = {
+    Name = "${var.name}-public-RT"
+  }
+}
+
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+
+
+
+
+
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+resource "aws_nat_gateway" "this" {
+  subnet_id     = aws_subnet.public.id
+  allocation_id = aws_eip.nat.id
+  tags = {
+    Name = "${var.name}-NGW"
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id                = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+  tags = {
+    Name = "${var.name}-private-RT"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
 }

--- a/v3/modules/vpc/outputs.tf
+++ b/v3/modules/vpc/outputs.tf
@@ -1,0 +1,4 @@
+output "vpc_id" {
+  description = "ID of the created VPC"
+  value       = aws_vpc.this.id
+}

--- a/v3/modules/vpc/variables.tf
+++ b/v3/modules/vpc/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "Prefix name for the VPC"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}

--- a/v3/modules/vpc/variables.tf
+++ b/v3/modules/vpc/variables.tf
@@ -7,3 +7,18 @@ variable "vpc_cidr" {
   description = "CIDR block for the VPC"
   type        = string
 }
+
+variable "public_subnet_cidr" {
+    description = "public subnet CIDR"
+    type = string
+}
+
+variable "private_subnet_cidr" {
+    description = "private subnet CIDR"
+    type = string
+}
+
+variable "subnet_az" {
+  type        = list(string)
+  description = "Availability zones to use"
+}


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- Terraform을 사용해 VPC 3-Tier 아키텍처 구성 코드를 작성했습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

- 프라이빗/퍼블릭 서브넷, IGW/NAT, 라우팅 테이블 등 3-Tier 인프라 기본 구성을 분리하고 모듈화하기 위함입니다.
- 추후 EKS, Kafka 등 인프라 컴포넌트 배치를 위한 네트워크 기반을 마련하고자 했습니다.

## Changes
> 주요 변경사항을 적습니다.

- `modules/vpc` 디렉토리 추가 및 VPC/서브넷/라우팅/IGW/NAT 구성
- `env/prod` 디렉토리에 환경별 VPC 구성 호출 코드 작성
- Terraform 리소스 구성에 필요한 `variables.tf`, `outputs.tf` 정의 포함

## Related Issue
> 관련 이슈 번호를 연결합니다.

- #76 
