### PR TITLE
Feat: add mysql-exporter to docker-compose for Signoz metric (#73)

### DIFF
--- a/v2/docker-compose.dev.yaml
+++ b/v2/docker-compose.dev.yaml
@@ -63,6 +63,20 @@ services:
       - nemo-net
     restart: unless-stopped
 
+  
+    mysql-exporter:
+      image: prom/mysqld-exporter
+      container_name: mysql-exporter
+      restart: unless-stopped
+      environment:
+        - DATA_SOURCE_NAME=mysql_exporter:nemo@(db:3306)/
+      ports:
+        - "9104:9104"
+      networks:
+        - nemo-net
+      depends_on:
+        - db
+
 networks:
   nemo-net:
 


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- docker-compose.dev.yaml에 mysql-exporter 서비스를 추가했습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

- Signoz에서 MySQL 관련 메트릭을 수집하여 APM 기반 모니터링을 강화하기 위함입니다.

## Changes
> 주요 변경사항을 적습니다.

- prom/mysqld-exporter 이미지 기반 컨테이너 추가
- nemo-net 네트워크에 연결
- 9104 포트로 exporter 서비스 노출

## Related Issue
> 관련 이슈 번호를 연결합니다.

- #73 
