### PR TITLE
Feat: deploy mysql-exporter for Signoz

### DIFF
--- a/v2/docker-compose.dev.yaml
+++ b/v2/docker-compose.dev.yaml
@@ -63,19 +63,18 @@ services:
       - nemo-net
     restart: unless-stopped
 
-  
-    mysql-exporter:
-      image: prom/mysqld-exporter
-      container_name: mysql-exporter
-      restart: unless-stopped
-      environment:
-        - DATA_SOURCE_NAME=mysql_exporter:nemo@(db:3306)/
-      ports:
-        - "9104:9104"
-      networks:
-        - nemo-net
-      depends_on:
-        - db
+  mysql-exporter:
+    image: prom/mysqld-exporter
+    container_name: mysql-exporter
+    restart: unless-stopped
+    environment:
+      - DATA_SOURCE_NAME=mysql_exporter:nemo@(db:3306)/
+    ports:
+      - "9104:9104"
+    networks:
+      - nemo-net
+    depends_on:
+      - db
 
 networks:
   nemo-net:

--- a/v2/docker-compose.dev.yaml
+++ b/v2/docker-compose.dev.yaml
@@ -75,6 +75,8 @@ services:
       - nemo-net
     depends_on:
       - db
+    volumes:
+      - ./.my.cnf:/.my.cnf:ro 
 
 networks:
   nemo-net:

--- a/v2/scripts/.my.cnf
+++ b/v2/scripts/.my.cnf
@@ -1,0 +1,5 @@
+# .my.cnf
+[client]
+user=mysql_exporter
+password=nemo
+host=db


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

-mysqld-exporter 컨테이너 구성 및 .my.cnf 파일을 통한 MySQL 인증 설정 추가

## Why
> 왜 이 작업을 했는지 설명합니다.

- MySQL의 내부 상태 지표를 SigNoz로 수집하기 위함

## Changes
> 주요 변경사항을 적습니다.

- docker-compose.dev.yaml에 mysqld-exporter 서비스 추가
- .my.cnf 파일 생성 및 컨테이너 내 /home/exporter/.my.cnf에 마운트

## Related Issue
> 관련 이슈 번호를 연결합니다.

- #73 
