### PR TITLE
Feat: 테라폼으로 ArgoCD 설치 및 Application에 대한 모든 부분 자동화 구성

### DIFF
--- a/v3/env/prod/.terraform.lock.hcl
+++ b/v3/env/prod/.terraform.lock.hcl
@@ -42,6 +42,25 @@ provider "registry.terraform.io/hashicorp/helm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.37.1"
+  hashes = [
+    "h1:+37jC6JlkPyPvDHudK3qaj7ZVJ0Zy9zc9+oq8h1WayA=",
+    "zh:0ed097413c7fc804479e325966886b405dc0b75ad2b4f54ce4df1d8e4802b397",
+    "zh:17dcf4a685a00d2d048671124e8a1a8e836b58ecd2ef628a1c666fe0ced2e598",
+    "zh:36891284e5bced57c438f12d0b27856b0d4b70b562bd200b01919a6a89545be9",
+    "zh:3e49d86b508e641ba122d1b0af24cdc4d8ffa2ec1b30022436fb1d7c6ba696ea",
+    "zh:40be623e116708bdcb0fac32989db43720f031c5fe9a4dc63395078185d24403",
+    "zh:44fc0ac3bc39e289b67f9dde7ee9fef29eb8192197e5e68fee69098573021722",
+    "zh:957aa451573bcde5d57f6f8338ea3139010c7f61fefe8f6a140a8c267f056511",
+    "zh:c55fd85b7e8acaac17e30670ac3574b88b3530820dd004bcd2a5daa8624a46e9",
+    "zh:c743f06843a1f5ecde2b8ef639f4d3db654a334ef248dee57261c719ea843f3a",
+    "zh:c93cc71c64b838d89522ac5fb60f68e0e1e7f2fc39db6b0ead7afd78795e79ed",
+    "zh:eda1163c2266905adc54bc78cc3e7b606a164fbc6b59be607db933b302015ccd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [

--- a/v3/env/prod/.terraform.lock.hcl
+++ b/v3/env/prod/.terraform.lock.hcl
@@ -41,3 +41,22 @@ provider "registry.terraform.io/hashicorp/helm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}

--- a/v3/env/prod/.terraform.lock.hcl
+++ b/v3/env/prod/.terraform.lock.hcl
@@ -22,3 +22,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "3.0.2"
+  hashes = [
+    "h1:tOye2RnjFNXH236AsqGaIWtz4j6PZrpPuJhOSBt0KxU=",
+    "zh:2778de76c7dfb2e85c75fe6de3c11172a25551ed499bfb9e9f940a5be81167b0",
+    "zh:3b4c436a41e4fbae5f152852a9bd5c97db4460af384e26977477a40adf036690",
+    "zh:617a372f5bb2288f3faf5fd4c878a68bf08541cf418a3dbb8a19bc41ad4a0bf2",
+    "zh:84de431479548c96cb61c495278e320f361e80ab4f8835a5425ece24a9b6d310",
+    "zh:8b4cf5f81d10214e5e1857d96cff60a382a22b9caded7f5d7a92e5537fc166c1",
+    "zh:baeb26a00ffbcf3d507cdd940b2a2887eee723af5d3319a53eec69048d5e341e",
+    "zh:ca05a8814e9bf5fbffcd642df3a8d9fae9549776c7057ceae6d6f56471bae80f",
+    "zh:ca4bf3f94dedb5c5b1a73568f2dad7daf0ef3f85e688bc8bc2d0e915ec148366",
+    "zh:d331f2129fd3165c4bda875c84a65555b22eb007801522b9e017d065ac69b67e",
+    "zh:e583b2b478dde67da28e605ab4ef6521c2e390299b471d7d8ef05a0b608dcdad",
+    "zh:f238b86611647c108c073d265f8891a2738d3158c247468ae0ff5b1a3ac4122a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/v3/env/prod/main.tf
+++ b/v3/env/prod/main.tf
@@ -33,4 +33,6 @@ module "argocd" {
   namespace           = "argocd"
   create_namespace    = true
   values              = [file("${path.module}/../../modules/argocd/values.yaml")]
+
+  depends_on = [null_resource.update_kubeconfig]
 }

--- a/v3/env/prod/main.tf
+++ b/v3/env/prod/main.tf
@@ -24,7 +24,6 @@ module "eks" {
   instance_types     = ["t3.large"]
 }
 
-
 module "argocd" {
   source             = "../../modules/argocd"
   name                = "argocd"
@@ -34,5 +33,6 @@ module "argocd" {
   create_namespace    = true
   values              = [file("${path.module}/../../modules/argocd/values.yaml")]
 
+  ## 중요 
   depends_on = [null_resource.update_kubeconfig]
 }

--- a/v3/env/prod/main.tf
+++ b/v3/env/prod/main.tf
@@ -23,3 +23,14 @@ module "eks" {
   min_capacity       = 1
   instance_types     = ["t3.large"]
 }
+
+
+module "argocd" {
+  source             = "../../modules/argocd"
+  name                = "argocd"
+  repository          = "https://argoproj.github.io/argo-helm"
+  chart               = "argo-cd"
+  namespace           = "argocd"
+  create_namespace    = true
+  values              = [file("${path.module}/../../modules/argocd/values.yaml")]
+}

--- a/v3/env/prod/provider.tf
+++ b/v3/env/prod/provider.tf
@@ -13,4 +13,5 @@ resource "null_resource" "update_kubeconfig" {
   provisioner "local-exec" {
     command = "aws eks update-kubeconfig --name nemo_EKS_kluster --region ap-northeast-2"
   }
+  depends_on = [module.eks]
 }

--- a/v3/env/prod/provider.tf
+++ b/v3/env/prod/provider.tf
@@ -1,3 +1,16 @@
 provider "aws" {
   region = "ap-northeast-2"
 }
+
+# Helm Provider (EKS 연결 자동화)
+provider "helm" {
+  kubernetes = {
+    config_path = "~/.kube/config"
+  }
+}
+
+resource "null_resource" "update_kubeconfig" {
+  provisioner "local-exec" {
+    command = "aws eks update-kubeconfig --name nemo_EKS_kluster --region ap-northeast-2"
+  }
+}

--- a/v3/env/prod/provider.tf
+++ b/v3/env/prod/provider.tf
@@ -9,9 +9,6 @@ provider "helm" {
   }
 }
 
-resource "null_resource" "update_kubeconfig" {
-  provisioner "local-exec" {
-    command = "aws eks update-kubeconfig --name nemo_EKS_kluster --region ap-northeast-2"
-  }
-  depends_on = [module.eks]
+provider "kubernetes" {
+  config_path = "~/.kube/config"
 }

--- a/v3/helm-charts/argocd/Chart.yaml
+++ b/v3/helm-charts/argocd/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: argocd
+description: Argo CD Helm chart wrapper for GitOps
+type: application
+version: 1.0.0

--- a/v3/helm-charts/argocd/values-prod.yaml
+++ b/v3/helm-charts/argocd/values-prod.yaml
@@ -1,0 +1,21 @@
+global:
+  domain: argocd.nemo.com  # 필요 시
+
+server:
+  service:
+    type: LoadBalancer  # 외부 공개 시
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - argocd.nemo.com
+    tls:
+      - hosts:
+          - argocd.nemo.com
+        secretName: argocd-tls
+
+configs:
+  params:
+    server.insecure: true  # HTTP 접속 허용 (테스트용)
+
+# adminPassword: bcrypt 해시도 설정 가능

--- a/v3/helm-charts/argocd/values-prod.yaml
+++ b/v3/helm-charts/argocd/values-prod.yaml
@@ -13,7 +13,7 @@ server:
       - hosts:
           - argocd.nemo.com
         secretName: argocd-tls
-
+        
 configs:
   params:
     server.insecure: true  # HTTP 접속 허용 (테스트용)

--- a/v3/k8s/argocd/argocd-app.yaml
+++ b/v3/k8s/argocd/argocd-app.yaml
@@ -1,23 +1,20 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ebs-csi-driver
+  name: argocd
   namespace: argocd
 spec:
   project: default
-
   source:
     repoURL: https://github.com/100-hours-a-week/6-nemo-cloud.git
     targetRevision: infra/terraform-setting
-    path: v3/helm-charts/ebs-csi-driver
+    path: v3/helm-charts/argocd
     helm:
       valueFiles:
         - values-prod.yaml
-        
   destination:
     server: https://kubernetes.default.svc
-    namespace: kube-system
-
+    namespace: argocd
   syncPolicy:
     automated:
       prune: true

--- a/v3/k8s/argocd/kafka-app.yaml
+++ b/v3/k8s/argocd/kafka-app.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kafka
-  namespace: kafka
+  namespace: argocd
+  ##  이 Application은 argocd 네임스페이스에 존재 -> ArgoCD가 이를 감지하고 UI에 표시함 
 spec:
   project: default
   source:
@@ -16,10 +17,11 @@ spec:
   destination:
     server: https://kubernetes.default.svc
     namespace: kafka
-
+    #### 이제 여기서 kafka 네임스페이스를 설치함 
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      ## Kafka 네임스페이스가 없으면 자동으로 생성함 

--- a/v3/k8s/argocd/kafka-app.yaml
+++ b/v3/k8s/argocd/kafka-app.yaml
@@ -2,13 +2,12 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: kafka
-  namespace: argocd
+  namespace: kafka
 spec:
   project: default
-
   source:
     repoURL: https://github.com/100-hours-a-week/6-nemo-cloud.git
-    targetRevision: infra/terraform 
+    targetRevision: infra/terraform-setting
     path: v3/helm-charts/kafka
     helm:
       valueFiles:

--- a/v3/modules/argocd/.terraform.lock.hcl
+++ b/v3/modules/argocd/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "3.0.2"
+  hashes = [
+    "h1:tOye2RnjFNXH236AsqGaIWtz4j6PZrpPuJhOSBt0KxU=",
+    "zh:2778de76c7dfb2e85c75fe6de3c11172a25551ed499bfb9e9f940a5be81167b0",
+    "zh:3b4c436a41e4fbae5f152852a9bd5c97db4460af384e26977477a40adf036690",
+    "zh:617a372f5bb2288f3faf5fd4c878a68bf08541cf418a3dbb8a19bc41ad4a0bf2",
+    "zh:84de431479548c96cb61c495278e320f361e80ab4f8835a5425ece24a9b6d310",
+    "zh:8b4cf5f81d10214e5e1857d96cff60a382a22b9caded7f5d7a92e5537fc166c1",
+    "zh:baeb26a00ffbcf3d507cdd940b2a2887eee723af5d3319a53eec69048d5e341e",
+    "zh:ca05a8814e9bf5fbffcd642df3a8d9fae9549776c7057ceae6d6f56471bae80f",
+    "zh:ca4bf3f94dedb5c5b1a73568f2dad7daf0ef3f85e688bc8bc2d0e915ec148366",
+    "zh:d331f2129fd3165c4bda875c84a65555b22eb007801522b9e017d065ac69b67e",
+    "zh:e583b2b478dde67da28e605ab4ef6521c2e390299b471d7d8ef05a0b608dcdad",
+    "zh:f238b86611647c108c073d265f8891a2738d3158c247468ae0ff5b1a3ac4122a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/v3/modules/argocd/main.tf
+++ b/v3/modules/argocd/main.tf
@@ -1,0 +1,8 @@
+resource "helm_release" "argocd" {
+  name                  = var.name
+  repository            = var.repository
+  chart                 = var.chart
+  namespace             = var.namespace
+  create_namespace      = var.create_namespace
+  values                = var.values
+}

--- a/v3/modules/argocd/values.yaml
+++ b/v3/modules/argocd/values.yaml
@@ -1,0 +1,9 @@
+controller:
+  args:
+    - --insecure
+  metrics:
+    enabled: true
+
+server:
+  service:
+    type: LoadBalancer

--- a/v3/modules/argocd/variables.tf
+++ b/v3/modules/argocd/variables.tf
@@ -1,0 +1,31 @@
+variable "name" {
+  description = "Helm release name"
+  type        = string
+}
+
+variable "repository" {
+  description = "Helm chart repository"
+  type        = string
+}
+
+variable "chart" {
+    description = "Helm chart name"
+    type        = string
+}
+
+variable "namespace" {
+    description =  "Kubernetes namespace for ArgoCD"
+    type        =  string
+}
+
+variable "create_namespace" {
+    description =  "Whether to create the namespace"
+    type        =  bool
+    default     =  true
+}
+
+variable "values" {
+  description = "List of values files"
+  type        = list(string)
+  default     = []
+}

--- a/v3/modules/eks/main.tf
+++ b/v3/modules/eks/main.tf
@@ -10,6 +10,9 @@ resource "aws_eks_cluster" "this" {
   depends_on = [aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy]
 }
 
+
+
+
 resource "aws_eks_node_group" "this" {
   cluster_name    = aws_eks_cluster.this.name
   node_group_name = var.node_group_name
@@ -158,3 +161,4 @@ resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
   role       = aws_iam_role.ebs_csi_driver.name
   policy_arn = aws_iam_policy.ebs_csi_driver.arn
 }
+


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- ArgoCD 애플리케이션 정의(`argocd-app.yaml`, `kafka-app.yaml`)를 Terraform으로 자동화
- `argocd-app.yaml`을 이용해 ArgoCD가 자기 자신을 관리하도록 구성
- `kafka-app.yaml`도 `kubernetes_manifest`로 GitOps 관리에 포함
- `depends_on`을 이용해 리소스 생성 순서를 명확히 설정

## Why
> 왜 이 작업을 했는지 설명합니다.

- 모든 `kubectl apply -f` 명령어를 제거하고 완전 자동화 달성
- ArgoCD 자체도 GitOps로 관리되도록 구성
- ArgoCD가 완전히 기동된 후에 Application이 배포되도록 순서 보장
- 인프라 구성을 모듈화하고 재현 가능하게 만들기 위함

## Changes
> 주요 변경사항을 적습니다.

-  Terraform에서 Helm 모듈로 ArgoCD 설치(`module "argocd"`)
- `null_resource.update_kubeconfig`로 kubeconfig 업데이트 자동화
- `kubernetes_manifest.argocd_app`으로 ArgoCD Application 리소스 적용
- `kubernetes_manifest.kafka_app`으로 Kafka 관련 GitOps 리소스 등록
- 모든 Application 리소스에 `depends_on = [module.argocd]` 추가하여 순서 보장
- YAML 파일 참조 경로 재정비하여 Terraform에서 올바르게 인식되도록 수정

## Related Issue
> 관련 이슈 번호를 연결합니다.

- #77 
