### PR TITLE
Feat: KRaft 모드에서 Zookeeper 모드로 Kafka 마이그레이션 

### DIFF
--- a/v3/helm-charts/kafka/templates/statefulset.yaml
+++ b/v3/helm-charts/kafka/templates/statefulset.yaml
@@ -43,8 +43,11 @@ spec:
                   fieldPath: metadata.name
 
             - name: KAFKA_CFG_ZOOKEEPER_CONNECT
-              value: "kafka-zookeeper-headless:2181"  # Assuming Zookeeper is deployed with this name
-              
+              value: >-
+                zookeeper-0.zookeeper-headless.kafka.svc.cluster.local:2181,
+                zookeeper-1.zookeeper-headless.kafka.svc.cluster.local:2181,
+                zookeeper-2.zookeeper-headless.kafka.svc.cluster.local:2181
+                
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
               value: "PLAINTEXT:PLAINTEXT"
 

--- a/v3/helm-charts/kafka/templates/statefulset.yaml
+++ b/v3/helm-charts/kafka/templates/statefulset.yaml
@@ -42,23 +42,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
 
-            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
-              value: "CONTROLLER"
-
-            - name: KAFKA_CFG_KRAFT_MODE
-              value: "true"
-
-            - name: KAFKA_CFG_PROCESS_ROLES
-              value: "controller,broker"
-
-            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
-              value: "{{ .Values.kraft.quorumVoters }}"
-
-            - name: KAFKA_KRAFT_CLUSTER_ID
-              value: "{{ .Values.kraft.clusterId }}"
-
+            - name: KAFKA_CFG_ZOOKEEPER_CONNECT
+              value: "kafka-zookeeper-headless:2181"  # Assuming Zookeeper is deployed with this name
+              
             - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-              value: "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+              value: "PLAINTEXT:PLAINTEXT"
 
             - name: KAFKA_CFG_LISTENERS
               value: "PLAINTEXT://:{{ .Values.container.port }},CONTROLLER://:{{ .Values.container.controllerPort }}"

--- a/v3/helm-charts/kafka/templates/statefulset.yaml
+++ b/v3/helm-charts/kafka/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
               value: "PLAINTEXT:PLAINTEXT"
 
             - name: KAFKA_CFG_LISTENERS
-              value: "PLAINTEXT://:{{ .Values.container.port }},CONTROLLER://:{{ .Values.container.controllerPort }}"
+              value: "PLAINTEXT://:{{ .Values.container.port }}"
 
             - name: KAFKA_CFG_ADVERTISED_LISTENERS
               value: "PLAINTEXT://$(POD_NAME).{{ .Values.service.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.container.port }}"

--- a/v3/helm-charts/kafka/values-prod.yaml
+++ b/v3/helm-charts/kafka/values-prod.yaml
@@ -44,12 +44,21 @@ affinity:
           topologyKey: topology.kubernetes.io/zone
 
 zookeeper:
+  enabled: true
+  replicaCount: 3
+  persistence:
+    enabled: true
+    storageClass: gp3
+    size: 10Gi
+
+    
+kraft:
   enabled: false
 
-kraft:
-  enabled: true
-  clusterId: 2N0jE9q6QDWYxidBhVkb5w  # 클러스터 고정 UUID
-  quorumVoters: |
-    0@kafka-controller-0.kafka-headless.kafka.svc.cluster.local:9093,\
-    1@kafka-controller-1.kafka-headless.kafka.svc.cluster.local:9093,\
-    2@kafka-controller-2.kafka-headless.kafka.svc.cluster.local:9093
+#kraft:
+#  enabled: true
+#  clusterId: 2N0jE9q6QDWYxidBhVkb5w  # 클러스터 고정 UUID
+#  quorumVoters: |
+#    0@kafka-controller-0.kafka-headless.kafka.svc.cluster.local:9093,\
+#    1@kafka-controller-1.kafka-headless.kafka.svc.cluster.local:9093,\
+#    2@kafka-controller-2.kafka-headless.kafka.svc.cluster.local:9093

--- a/v3/helm-charts/zookeeper/Chart.yaml
+++ b/v3/helm-charts/zookeeper/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: zookeeper
+description: A Helm chart for deploying Zookeeper
+type: application
+version: 0.1.0
+appVersion: 3.8.4

--- a/v3/helm-charts/zookeeper/templates/headless-service.yaml
+++ b/v3/helm-charts/zookeeper/templates/headless-service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   name: {{ .Values.service.name }}-headless
   labels:
-    app: {{ include "zookeeper.name" . }}
+    app: {{ .Chart.Name }}
 spec:
   clusterIP: None
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   selector:
-    app: {{ include "zookeeper.name" . }}
+    app: {{ .Chart.Name }}

--- a/v3/helm-charts/zookeeper/templates/headless-service.yaml
+++ b/v3/helm-charts/zookeeper/templates/headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}-headless
+  labels:
+    app: {{ include "zookeeper.name" . }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ include "zookeeper.name" . }}

--- a/v3/helm-charts/zookeeper/templates/service.yaml
+++ b/v3/helm-charts/zookeeper/templates/service.yaml
@@ -8,4 +8,4 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
   selector:
-    app: {{ include "zookeeper.name" . }}
+    app: {{ .Chart.Name }}

--- a/v3/helm-charts/zookeeper/templates/service.yaml
+++ b/v3/helm-charts/zookeeper/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ include "zookeeper.name" . }}

--- a/v3/helm-charts/zookeeper/templates/statefulset.yaml
+++ b/v3/helm-charts/zookeeper/templates/statefulset.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: {{ .Chart.Name  }}
     spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 1001
       containers:
         - name: zookeeper
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/v3/helm-charts/zookeeper/templates/statefulset.yaml
+++ b/v3/helm-charts/zookeeper/templates/statefulset.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "zookeeper.fullname" . }}
+  name: {{ .Chart.Name }}
   labels:
-    app: {{ include "zookeeper.name" . }}
+    app: {{ .Chart.Name }}
 spec:
   serviceName: {{ .Values.service.name }}-headless
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "zookeeper.name" . }}
+      app: {{ .Chart.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "zookeeper.name" . }}
+        app: {{ .Chart.Name  }}
     spec:
       containers:
         - name: zookeeper
@@ -23,14 +23,16 @@ spec:
             - containerPort: {{ .Values.service.port }}
           env:
             - name: ZOO_SERVERS
-              value: >-
+              value: |-
                 {{- range $i, $e := until (.Values.replicaCount | int) }}
                 server.{{ $i }}={{ $.Values.service.name }}-{{ $i }}.{{ $.Values.service.name }}-headless:2888:3888
                 {{- end }}
-            - name: ZOO_MY_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+          command:
+            - sh
+            - -c
+            - |
+              export ZOO_MY_ID=$(hostname | awk -F '-' '{print $NF}');
+              exec /opt/bitnami/scripts/zookeeper/run.sh
           volumeMounts:
             - name: data
               mountPath: /bitnami/zookeeper

--- a/v3/helm-charts/zookeeper/templates/statefulset.yaml
+++ b/v3/helm-charts/zookeeper/templates/statefulset.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "zookeeper.fullname" . }}
+  labels:
+    app: {{ include "zookeeper.name" . }}
+spec:
+  serviceName: {{ .Values.service.name }}-headless
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "zookeeper.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "zookeeper.name" . }}
+    spec:
+      containers:
+        - name: zookeeper
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            - name: ZOO_SERVERS
+              value: >-
+                {{- range $i, $e := until (.Values.replicaCount | int) }}
+                server.{{ $i }}={{ $.Values.service.name }}-{{ $i }}.{{ $.Values.service.name }}-headless:2888:3888
+                {{- end }}
+            - name: ZOO_MY_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/zookeeper
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.persistence.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}

--- a/v3/helm-charts/zookeeper/templates/statefulset.yaml
+++ b/v3/helm-charts/zookeeper/templates/statefulset.yaml
@@ -27,12 +27,12 @@ spec:
                 {{- range $i, $e := until (.Values.replicaCount | int) }}
                 server.{{ $i }}={{ $.Values.service.name }}-{{ $i }}.{{ $.Values.service.name }}-headless:2888:3888
                 {{- end }}
-          command:
-            - sh
-            - -c
-            - |
-              export ZOO_MY_ID=$(hostname | awk -F '-' '{print $NF}');
-              exec /opt/bitnami/scripts/zookeeper/run.sh
+            - name: ZOO_MY_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ALLOW_ANONYMOUS_LOGIN
+              value: "yes"
           volumeMounts:
             - name: data
               mountPath: /bitnami/zookeeper

--- a/v3/helm-charts/zookeeper/values-prod.yaml
+++ b/v3/helm-charts/zookeeper/values-prod.yaml
@@ -23,3 +23,5 @@ resources:
   requests:
     cpu: 100m
     memory: 256Mi
+
+

--- a/v3/helm-charts/zookeeper/values-prod.yaml
+++ b/v3/helm-charts/zookeeper/values-prod.yaml
@@ -1,0 +1,25 @@
+replicaCount: 3
+
+image:
+  repository: bitnami/zookeeper
+  tag: 3.8.4
+  pullPolicy: IfNotPresent
+
+service:
+  name: zookeeper
+  type: ClusterIP
+  port: 2181
+  headless: true
+
+persistence:
+  enabled: true
+  size: 5Gi
+  storageClass: gp3
+
+resources:
+  limits:
+    cpu: 250m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/v3/k8s/argocd/zookeeper-app.yaml
+++ b/v3/k8s/argocd/zookeeper-app.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zookeeper
+  ## 이 Application의 이름은 zookeeper -> ArgoCD가 이를 감지하고 UI 
+  namespace: argocd
+  ##  이 Application은 argocd 네임스페이스에 존재 -> ArgoCD가 이를 감지하고 UI에 표시함 
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/100-hours-a-week/6-nemo-cloud.git
+    targetRevision: infra/terraform-setting
+    path: v3/helm-charts/zookeeper
+    helm:
+      valueFiles:
+        - values-prod.yaml
+        
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kafka
+    #### 이제 여기서 kafka 네임스페이스를 설치함 
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      ## Kafka 네임스페이스가 없으면 자동으로 생성함 


### PR DESCRIPTION
## What
> 무엇을 작업했는지 간결하게 적습니다.

- Kafka를 Kraft 모드에서 Zookeeper 기반 모드로 마이그레이션했습니다.
- Zookeeper용 Helm Chart를 새로 추가하고, Kafka Chart와 연결되도록 구성했습니다.
- ArgoCD Application manifest를 추가하여 Zookeeper 배포를 GitOps로 관리할 수 있도록 했습니다.
- Bitnami 기반 Zookeeper에 대한 custom command 제거 및 익명 접속 허용 설정을 반영했습니다.

## Why
> 왜 이 작업을 했는지 설명합니다.

- Kafka는 최근 KRaft 모드를 도입했지만, 현업에서는 여전히 Zookeeper 기반 구성이 더 안정적이고 많이 사용됩니다.
- Zookeeper 기반은 수년간 검증되어 운영에 필요한 모니터링, 보안 설정, 장애 대응 등에서 성숙한 지원을 받습니다.
- 본 PR에서는 Kafka-Zookeeper 구성을 Helm Chart와 ArgoCD를 통해 코드 기반으로 자동화하여, 운영 환경에서도 활용 가능한 기반을 마련하고자 하였습니다.

## Changes
> 주요 변경사항을 적습니다.

- `charts/zookeeper` 디렉토리에 Zookeeper Helm Chart 추가
- Kafka StatefulSet에서 `KAFKA_CFG_ZOOKEEPER_CONNECT` 환경 변수 구성
- Bitnami Zookeeper의 custom command 제거 및 `ALLOW_ANONYMOUS_LOGIN=yes` 설정
- Zookeeper volume permission 설정 (initContainer 추가)
- ArgoCD Application manifest (`zookeeper-application.yaml`) 추가

## Related Issue
> 관련 이슈 번호를 연결합니다.

- #96 
